### PR TITLE
Update Balena token secret in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: balena-io/deploy-to-balena-action@master
         id: build
         with:
-          balena_token: ${{ secrets.BALENA_TOKEN }}
+          balena_token: ${{ secrets.BALENA_API_KEY }}
           fleet: techops_balena1/octo-browser
       - name: Log release ID built
         run: echo "Built release ID ${{ steps.build.outputs.release_id }}"


### PR DESCRIPTION
default for the balena_token entry is BALENA_TOKEN, but the secret has been set as BALENA_API_KEY