### PR TITLE
fix device tag not hiding on chrome

### DIFF
--- a/extensions/cosd_cat/scripts/content.js
+++ b/extensions/cosd_cat/scripts/content.js
@@ -21,7 +21,7 @@ font-size: calc(var(--font-size) / var(--balena-display-scale));`;
 
 async function setOSD(config) {
     // get the entire extension storage object
-    if (config.balenaId != undefined) {
+    if (config.balenaId != undefined && config.showDeviceTag != "0") {
         // set the device slug
         cat.innerHTML = config.balenaId;
 


### PR DESCRIPTION
There was never any logic to hide the device tag when using Chrome, it only existed when playing videos with mpv.