### PR TITLE
restart the entire container when a monitor is hotplugged

### DIFF
--- a/src/setupkanshi.sh
+++ b/src/setupkanshi.sh
@@ -10,9 +10,10 @@ for f in /sys/class/drm/*; do
         cat >> ~/.config/kanshi/config <<EOL
 profile {
 	output ${name} enable scale ${DISPLAY_SCALE} transform ${ROTATE_DISPLAY}
+    exec if [ ! -f /var/lock/chromium-starting.lock ]; then echo "kanshi: Restarting container upon screen hotplug" && pkill chromium; fi
 }
 EOL
     fi
 done
 
-kanshi
+kanshi &

--- a/src/startcage.sh
+++ b/src/startcage.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+touch /var/lock/chromium-starting.lock
+
 # these two lines remove the "restore pages" popup on chromium. 
 sed -i 's/"exited_cleanly":false/"exited_cleanly":true/' /data/chromium/'Local State' > /dev/null 2>&1 || true 
 sed -i 's/"exited_cleanly":false/"exited_cleanly":true/; s/"exit_type":"[^"]\+"/"exit_type":"Normal"/' /data/chromium/Default/Preferences > /dev/null 2>&1 || true 
@@ -8,6 +10,8 @@ sed -i 's/"exited_cleanly":false/"exited_cleanly":true/; s/"exit_type":"[^"]\+"/
 export VERSION=`chromium --version`
 echo "Installed browser version: $VERSION"
 
-/usr/src/app/setupkanshi.sh &
+/usr/src/app/setupkanshi.sh
 
 node /usr/src/app/server.js
+
+pkill kanshi


### PR DESCRIPTION
Currently, the container will continue running when hotplugged and the display scale and rotation will be set by Kanshi upon plugging back in.

This causes a couple of problems. Kiosk mode seems to have an issue with rendering after this happens, and the scaling doesn't seem quite right - it's as if it's been scaled, but not using HIDPI methods.

This PR will have the container restart when kanshi detects that a monitor has been plugged back in.