### PR TITLE
add configurable timeout after user has stopped interactions

### DIFF
--- a/extensions/cosd_cat/scripts/content.js
+++ b/extensions/cosd_cat/scripts/content.js
@@ -1,4 +1,5 @@
 const cat = document.createElement("div");
+
 const fillTagElement =
     window.location.href.includes(chrome.runtime.id + "/pages/error") ||
     window.location.href.includes(chrome.runtime.id + "/pages/unconfigured");
@@ -76,9 +77,32 @@ function waitForBody() {
 }
 
 function updateLocation(location) {
+    // ask the service worker to update the URL in the browser
     chrome.runtime.sendMessage(chrome.runtime.id, {
         type: "updateLocation",
         url: location,
+    });
+}
+
+async function setupInteractionTimeout(config) {
+    console.log(config);
+    if (
+        isNaN(config.interactionTimeout) ||
+        config.interactionTimeout == 0 ||
+        config.interactionTimeout < 0
+    ) { return }
+    const interactionEvents = ['touchend', 'mouseup', 'keyup', 'wheel'];
+    let timeout = config.interactionTimeout * 1000 < 5000 ? 5000 : config.interactionTimeout * 1000; // don't let the refresh be less than 5 seconds
+
+    interactionEvents.forEach(eventType => {
+        // Use passive: true for better scroll/touch performance
+        document.addEventListener(eventType, () => {
+            chrome.runtime.sendMessage(chrome.runtime.id, {
+                type: "interactionTimeout",
+                url: config.startingUrl,
+                timeout: timeout
+            })
+        }, { passive: true });
     });
 }
 
@@ -97,9 +121,10 @@ fetch(chrome.runtime.getURL("config.json"))
         resp.json().then((config) => {
             if (startPage) {
                 console.log(`Redirecting to ${config.startingUrl}`);
-                setTimeout(() => {updateLocation(config.startingUrl)}, 1000);
+                setTimeout(updateLocation, 1000, config.startingUrl);
             } else {
                 setOSD(config);
+                setupInteractionTimeout(config);
             }
         });
     })

--- a/extensions/cosd_cat/scripts/service-worker.js
+++ b/extensions/cosd_cat/scripts/service-worker.js
@@ -1,4 +1,5 @@
 const tabErrors = {};
+const userInteractionTimers = {}
 
 const configPromise = fetch(chrome.runtime.getURL("config.json"))
     .then((response) => {
@@ -19,6 +20,16 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         sendResponse(tabErrors[sender.tab.id]);
     } else if (request.type == "updateLocation") {
         chrome.tabs.update(sender.tab.id, { url: request.url });
+    } else if (request.type == "interactionTimeout") {
+        if (userInteractionTimers[sender.tab.id] != null) {
+            clearTimeout(userInteractionTimers[sender.tab.id]);
+        }
+        userInteractionTimers[sender.tab.id] = setTimeout(
+            chrome.tabs.update,
+            request.timeout,
+            sender.tab.id,
+            { url: request.url }
+        );
     }
 });
 

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ const LAUNCH_URLS = (
 ).split(",");
 const UPSTREAM_URL = process.env.UPSTREAM_URL;
 const REFRESH_SCHEDULE = process.env.REFRESH_SCHEDULE || 0;
+const INTERACTION_TIMEOUT = process.env.INTERACTION_TIMEOUT || 0;
 const ROTATE_SCHEDULE = process.env.ROTATE_SCHEDULE || 0;
 const RELOAD_ON_ERROR = process.env.RELOAD_ON_ERROR || 0;
 const RELOAD_ON_ERROR_TIMER = (process.env.RELOAD_ON_ERROR_TIMER || 5) * 1000;
@@ -194,7 +195,8 @@ async function setExtensionStorage(startingUrl) {
         reloadOnErrorTimer: RELOAD_ON_ERROR_TIMER,
         upstreamUrl: UPSTREAM_URL,
         startingUrl: startingUrl,
-        showCursor: SHOW_CURSOR
+        showCursor: SHOW_CURSOR,
+        interactionTimeout: INTERACTION_TIMEOUT
     };
     const jsonData = JSON.stringify(extensionConfig);
 


### PR DESCRIPTION
Add capability to refresh the page after no interactivity has been detected on an interactive dashboard.

Functionality:
1. Receive touch & mouse events from the webpage (some touch layers present themselves as mice)
2. Cancel running timer (if it exists)
3. Start a timer that counts down from the value configured in environment variable `INTERACTION_TIMEOUT`
4. If the timer runs down before it is cancelled, the page is refreshed